### PR TITLE
Turn on OnUpdateTransform calls in 4.11.

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
@@ -16,6 +16,9 @@ UFMODAudioComponent::UFMODAudioComponent(const FObjectInitializer& ObjectInitial
 	bEnableTimelineCallbacks = false; // Default OFF for efficiency
 	bStopWhenOwnerDestroyed = true;
 	bNeverNeedsRenderUpdate = true;
+#if ENGINE_MINOR_VERSION >= 11
+	bWantsOnUpdateTransform = true;
+#endif
 #if WITH_EDITORONLY_DATA
 	bVisualizeComponent = true;
 #endif


### PR DESCRIPTION
In 4.11 the USceneComponent::OnUpdateTransform function is only called if the new bWantsOnUpdateTransform member variable is set to true.

More detail here: https://www.unrealengine.com/blog/unreal-engine-4-11-released