### PR TITLE
changed EWorldType::Preview and TabManager variable name

### DIFF
--- a/FMODStudio/Source/FMODStudio/Public/FMODUtils.h
+++ b/FMODStudio/Source/FMODStudio/Public/FMODUtils.h
@@ -71,7 +71,7 @@ inline bool IsWorldAudible(UWorld* World)
 #if ENGINE_MINOR_VERSION >= 14
 			previewEnum = EWorldType::EditorPreview;
 #else
-			previewEnum = EWorldType::GamePreview;
+			previewEnum = EWorldType::Preview;
 #endif
 			if (World->IsGameWorld() || World->WorldType == previewEnum)
 			{

--- a/FMODStudio/Source/FMODStudio/Public/FMODUtils.h
+++ b/FMODStudio/Source/FMODStudio/Public/FMODUtils.h
@@ -71,7 +71,7 @@ inline bool IsWorldAudible(UWorld* World)
 #if ENGINE_MINOR_VERSION >= 14
 			previewEnum = EWorldType::EditorPreview;
 #else
-			previewEnum = EWorldType::Preview;
+			previewEnum = EWorldType::GamePreview;
 #endif
 			if (World->IsGameWorld() || World->WorldType == previewEnum)
 			{

--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODEventEditor.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODEventEditor.cpp
@@ -17,25 +17,25 @@ DEFINE_LOG_CATEGORY_STATIC(LogFMODEventEditor, Log, All);
 const FName FFMODEventEditor::EventEditorTabId(TEXT("FFMODEventEditor_EventView"));
 const FName FFMODEventEditor::FMODEventEditorAppIdentifier(TEXT("FMODEventEditorApp"));
 
-void FFMODEventEditor::RegisterTabSpawners(const TSharedRef<class FTabManager>& TabManager)
+void FFMODEventEditor::RegisterTabSpawners(const TSharedRef<class FTabManager>& NewTabManager)
 {
-	WorkspaceMenuCategory = TabManager->AddLocalWorkspaceMenuCategory(LOCTEXT("WorkspaceMenu_FMODEventEditor", "FMOD Event Editor"));
+	WorkspaceMenuCategory = NewTabManager->AddLocalWorkspaceMenuCategory(LOCTEXT("WorkspaceMenu_FMODEventEditor", "FMOD Event Editor"));
 	auto WorkspaceMenuCategoryRef = WorkspaceMenuCategory.ToSharedRef();
 
-	FAssetEditorToolkit::RegisterTabSpawners(TabManager);
+	FAssetEditorToolkit::RegisterTabSpawners(NewTabManager);
 
-	TabManager->RegisterTabSpawner(
+	NewTabManager->RegisterTabSpawner(
 		EventEditorTabId,
 		FOnSpawnTab::CreateSP(this, &FFMODEventEditor::SpawnTab_EventEditor))
 		.SetDisplayName(LOCTEXT("EventTab", "FMOD Event"))
 		.SetGroup(WorkspaceMenuCategoryRef);
 }
 
-void FFMODEventEditor::UnregisterTabSpawners(const TSharedRef<class FTabManager>& TabManager)
+void FFMODEventEditor::UnregisterTabSpawners(const TSharedRef<class FTabManager>& NewTabManager)
 {
-	FAssetEditorToolkit::UnregisterTabSpawners(TabManager);
+	FAssetEditorToolkit::UnregisterTabSpawners(NewTabManager);
 
-	TabManager->UnregisterTabSpawner(EventEditorTabId);
+	NewTabManager->UnregisterTabSpawner(EventEditorTabId);
 }
 
 FFMODEventEditor::FFMODEventEditor()

--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODEventEditor.h
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODEventEditor.h
@@ -17,8 +17,8 @@ namespace FMOD
 class FFMODEventEditor : public FAssetEditorToolkit
 {
 public:
-	virtual void RegisterTabSpawners(const TSharedRef<class FTabManager>& TabManager) override;
-	virtual void UnregisterTabSpawners(const TSharedRef<class FTabManager>& TabManager) override;
+	virtual void RegisterTabSpawners(const TSharedRef<class FTabManager>& NewTabManager) override;
+	virtual void UnregisterTabSpawners(const TSharedRef<class FTabManager>& NewTabManager) override;
 
 	/**
 	* Edits the specified event


### PR DESCRIPTION
Changes for UE 4.14

### Changed EWorldType::Preview  to EWorldType::GamePreview in FMODUtils.h

I had warnings:
```
warning C4996: 'EWorldType::Preview': EWorldType::Preview is deprecated. Please use either EWorldType::EditorPreview or EWorldType::GamePreview Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.
```

### Changed the variable name TabManager to NewTabManager in FMODEventEditor.h and FMODEventEditor.cpp

I had warnings:
`warning C4458: declaration of 'TabManager' hides class member`