### PR TITLE
Fixed Compiler Issues relating to IWYU enabled projects

### DIFF
--- a/FMODStudio/Source/FMODStudio/Classes/FMODAsset.h
+++ b/FMODStudio/Source/FMODStudio/Classes/FMODAsset.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include "UObject/ObjectMacros.h"
+#include "UObject/Object.h"
+#include "Misc/Guid.h"
 #include "FMODAsset.generated.h"
 
 /**

--- a/FMODStudio/Source/FMODStudio/Classes/FMODAudioComponent.h
+++ b/FMODStudio/Source/FMODStudio/Classes/FMODAudioComponent.h
@@ -5,6 +5,7 @@
 #include "Map.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "Sound/SoundAttenuation.h"
+#include "Audio.h"
 #include "FMODAudioComponent.generated.h"
 
 // Event property

--- a/FMODStudio/Source/FMODStudio/Classes/FMODAudioComponent.h
+++ b/FMODStudio/Source/FMODStudio/Classes/FMODAudioComponent.h
@@ -5,7 +5,11 @@
 #include "Map.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "Sound/SoundAttenuation.h"
+
+// UE Includes
 #include "Audio.h"
+#include "Components/SceneComponent.h"
+
 #include "FMODAudioComponent.generated.h"
 
 // Event property

--- a/FMODStudio/Source/FMODStudio/Classes/FMODBlueprintStatics.h
+++ b/FMODStudio/Source/FMODStudio/Classes/FMODBlueprintStatics.h
@@ -4,6 +4,7 @@
 
 #include "UnrealString.h"
 #include "FMODAudioComponent.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "FMODBlueprintStatics.generated.h"
 
 class UFMODAudioComponent;

--- a/FMODStudio/Source/FMODStudio/Public/FMODUtils.h
+++ b/FMODStudio/Source/FMODStudio/Public/FMODUtils.h
@@ -6,6 +6,7 @@
 #include "fmod.hpp"
 
 #include "Runtime/Launch/Resources/Version.h"
+#include "Engine/Engine.h"
 
 #include "FMODStudioModule.h"
 


### PR DESCRIPTION
Project was failing to compile on an [Include What You Use](https://forums.unrealengine.com/showthread.php?129610-Iwyu&p=627943&viewfull=1#post627943) enabled projects.

Simply had to include two missing headers and all was well.

Additionally the UE4 Windows Plugin download from your website has the intermediate directory included as well. Is that intentional?