### PR TITLE
Update to support UE4.17

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODBlueprintStatics.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODBlueprintStatics.cpp
@@ -31,7 +31,11 @@ FFMODEventInstance UFMODBlueprintStatics::PlayEventAtLocation(UObject* WorldCont
 	FFMODEventInstance Instance;
 	Instance.Instance = nullptr;
 	
+#if ENGINE_MINOR_VERSION >= 17
+	UWorld* ThisWorld = GEngine->GetWorldFromContextObjectChecked(WorldContextObject);
+#else
 	UWorld* ThisWorld = GEngine->GetWorldFromContextObject(WorldContextObject);
+#endif
 	if (FMODUtils::IsWorldAudible(ThisWorld, false))
 	{
 		FMOD::Studio::EventDescription* EventDesc = IFMODStudioModule::Get().GetEventDescription(Event);

--- a/FMODStudio/Source/FMODStudio/Private/FMODStudioModule.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODStudioModule.cpp
@@ -116,9 +116,9 @@ public:
 		bUseSound(true),
 		bListenerMoved(true),
 		bAllowLiveUpdate(true),
+		bBanksLoaded(false),
 		LowLevelLibHandle(nullptr),
-		StudioLibHandle(nullptr),
-		bBanksLoaded(false)
+		StudioLibHandle(nullptr)
 	{
 		for (int i = 0; i < EFMODSystemContext::Max; ++i)
 		{

--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODAudioComponentVisualizer.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODAudioComponentVisualizer.cpp
@@ -24,7 +24,7 @@ void FFMODAudioComponentVisualizer::DrawVisualization(const UActorComponent* Com
 					const FColor AudioOuterRadiusColor(255, 153, 0);
 					const FColor AudioInnerRadiusColor(216, 130, 0);
 
-					const FTransform& Transform = AudioComp->ComponentToWorld;
+					const FTransform& Transform = AudioComp->GetComponentTransform();
 
 					float MinDistance = 0.0f;
 					float MaxDistance = 0.0f;

--- a/FMODStudio/Source/FMODStudioEditor/Private/Sequencer/FMODEventControlTrackEditor.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/Sequencer/FMODEventControlTrackEditor.cpp
@@ -112,12 +112,17 @@ int32 FFMODEventControlSection::OnPaintSection(FSequencerSectionPainter& InPaint
     {
         float XOffset = TimeToPixelConverter.TimeToPixel(DrawRange.GetLowerBoundValue());
         float XSize = TimeToPixelConverter.TimeToPixel(DrawRange.GetUpperBoundValue()) - XOffset;
+#if ENGINE_MINOR_VERSION >= 17
+        InPainter.DrawElements.PushClip(FSlateClippingZone(InPainter.SectionClippingRect));
+#endif
         FSlateDrawElement::MakeBox(
             InPainter.DrawElements,
             InPainter.LayerId,
             InPainter.SectionGeometry.ToPaintGeometry(FVector2D(XOffset, (InPainter.SectionGeometry.GetLocalSize().Y - SequencerSectionConstants::KeySize.Y) / 2), FVector2D(XSize, SequencerSectionConstants::KeySize.Y)),
             FEditorStyle::GetBrush("Sequencer.Section.Background"),
+#if ENGINE_MINOR_VERSION < 17
             InPainter.SectionClippingRect,
+#endif
             DrawEffects
         );
         FSlateDrawElement::MakeBox(
@@ -125,10 +130,15 @@ int32 FFMODEventControlSection::OnPaintSection(FSequencerSectionPainter& InPaint
             InPainter.LayerId,
             InPainter.SectionGeometry.ToPaintGeometry(FVector2D(XOffset, (InPainter.SectionGeometry.GetLocalSize().Y - SequencerSectionConstants::KeySize.Y) / 2), FVector2D(XSize, SequencerSectionConstants::KeySize.Y)),
             FEditorStyle::GetBrush("Sequencer.Section.BackgroundTint"),
+#if ENGINE_MINOR_VERSION < 17
             InPainter.SectionClippingRect,
+#endif
             DrawEffects,
             TrackColor
         );
+#if ENGINE_MINOR_VERSION >= 17
+        InPainter.DrawElements.PopClip();
+#endif
     }
 
     return InPainter.LayerId + 1;
@@ -220,7 +230,11 @@ void FFMODEventControlTrackEditor::AddControlKey(const FGuid ObjectGuid)
     }
 }
 
+#if ENGINE_MINOR_VERSION >= 17
+FKeyPropertyResult FFMODEventControlTrackEditor::AddKeyInternal(float KeyTime, UObject* Object)
+#else
 bool FFMODEventControlTrackEditor::AddKeyInternal(float KeyTime, UObject* Object)
+#endif
 {
     bool bHandleCreated = false;
     bool bTrackCreated = false;
@@ -243,7 +257,14 @@ bool FFMODEventControlTrackEditor::AddKeyInternal(float KeyTime, UObject* Object
         }
     }
 
+#if ENGINE_MINOR_VERSION >= 17
+    FKeyPropertyResult Result;
+    Result.bHandleCreated = bHandleCreated;
+    Result.bTrackCreated = bTrackCreated;
+    return Result;
+#else
     return bHandleCreated || bTrackCreated;
+#endif
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/FMODStudio/Source/FMODStudioEditor/Private/Sequencer/FMODEventControlTrackEditor.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/Sequencer/FMODEventControlTrackEditor.cpp
@@ -112,9 +112,6 @@ int32 FFMODEventControlSection::OnPaintSection(FSequencerSectionPainter& InPaint
     {
         float XOffset = TimeToPixelConverter.TimeToPixel(DrawRange.GetLowerBoundValue());
         float XSize = TimeToPixelConverter.TimeToPixel(DrawRange.GetUpperBoundValue()) - XOffset;
-#if ENGINE_MINOR_VERSION >= 17
-        InPainter.DrawElements.PushClip(FSlateClippingZone(InPainter.SectionClippingRect));
-#endif
         FSlateDrawElement::MakeBox(
             InPainter.DrawElements,
             InPainter.LayerId,
@@ -136,9 +133,6 @@ int32 FFMODEventControlSection::OnPaintSection(FSequencerSectionPainter& InPaint
             DrawEffects,
             TrackColor
         );
-#if ENGINE_MINOR_VERSION >= 17
-        InPainter.DrawElements.PopClip();
-#endif
     }
 
     return InPainter.LayerId + 1;

--- a/FMODStudio/Source/FMODStudioEditor/Private/Sequencer/FMODEventControlTrackEditor.h
+++ b/FMODStudio/Source/FMODStudioEditor/Private/Sequencer/FMODEventControlTrackEditor.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "Runtime/Launch/Resources/Version.h"
+
 /** FMOD Event control track */
 class FFMODEventControlTrackEditor : public FMovieSceneTrackEditor
 {
@@ -21,7 +23,11 @@ public:
 private:
 
     /** Delegate for AnimatablePropertyChanged in AddKey. */
+#if ENGINE_MINOR_VERSION >= 17
+    virtual FKeyPropertyResult AddKeyInternal(float KeyTime, UObject* Object);
+#else
     virtual bool AddKeyInternal(float KeyTime, UObject* Object);
+#endif
 };
 
 


### PR DESCRIPTION
These are the changes necessary for FMODStudio plugin to compile with UE4.17. 

Most of the changes are straight-forward, one that I'm not sure of is the PushClip()/PopClip(). The UE documentation is not existent on that one, as well as the official Release Notes for 4.17.

I also fixed one initialization order warning in FMODStudioModule as an extra ;-)