### PR TITLE
Adding Blueprintable to UFMODAudioComponent

### DIFF
--- a/FMODStudio/Source/FMODStudio/Classes/FMODAudioComponent.h
+++ b/FMODStudio/Source/FMODStudio/Classes/FMODAudioComponent.h
@@ -142,7 +142,7 @@ struct FMOD_STUDIO_TIMELINE_BEAT_PROPERTIES;
 /**
  * Plays FMOD Studio events.
  */
-UCLASS(ClassGroup = (Audio, Common), hidecategories = (Object, ActorComponent, Physics, Rendering, Mobility, LOD), ShowCategories = Trigger, meta = (BlueprintSpawnableComponent))
+UCLASS(Blueprintable, ClassGroup = (Audio, Common), hidecategories = (Object, ActorComponent, Physics, Rendering, Mobility, LOD), ShowCategories = Trigger, meta = (BlueprintSpawnableComponent))
 class FMODSTUDIO_API UFMODAudioComponent : public USceneComponent
 {
 	GENERATED_UCLASS_BODY()


### PR DESCRIPTION
This is a change I have been using locally for our last project.  It allows the extension of UFMODAudioComponent via blueprints.