### PR TITLE
Fix unnecessary ticks in FMODAudioComponent

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
@@ -32,6 +32,7 @@ UFMODAudioComponent::UFMODAudioComponent(const FObjectInitializer& ObjectInitial
     bDefaultParameterValuesCached = false;
 
 	PrimaryComponentTick.bCanEverTick = true;
+	PrimaryComponentTick.bStartWithTickEnabled = false;
 	PrimaryComponentTick.TickGroup = TG_PrePhysics;
 
 	StudioInstance = nullptr;


### PR DESCRIPTION
Currently `FMODAudioComponent` uses the default value for `PrimaryComponentTick.bStartWithTickEnabled`, which is `true`. This causes the component to tick, even if Auto Activate is disabled. In that case the `TickComponent()` function won't even do anything, because it checks the `bIsActive` flag.

Setting `PrimaryComponentTick.bStartWithTickEnabled` to `false` in the constructor solves this problem. Whenever the event is started `PlayInternal()` will activate the tick by calling `SetComponentTickEnabled(true)`.