### PR TITLE
Update FMODStudio.Build.cs to match new UE workflow

### DIFF
--- a/FMODStudio/Source/FMODStudio/FMODStudio.Build.cs
+++ b/FMODStudio/Source/FMODStudio/FMODStudio.Build.cs
@@ -1,4 +1,5 @@
 // Copyright (c), Firelight Technologies Pty, Ltd. 2012-2018.
+using System.IO;
 
 namespace UnrealBuildTool.Rules
 {
@@ -15,17 +16,7 @@ namespace UnrealBuildTool.Rules
 			
 			bFasterWithoutUnity = true;
 
-			PublicIncludePaths.AddRange(
-				new string[] {
-				}
-				);
-
-			PrivateIncludePaths.AddRange(
-				new string[] {
-					"FMODStudio/Private",
-					"FMODStudio/Public/FMOD",
-				}
-				);
+			PublicSystemIncludePaths.Add(Path.Combine(ModuleDirectory, "Public/FMOD"));
 
 			PublicDependencyModuleNames.AddRange(
 				new string[]


### PR DESCRIPTION
1. Use `PublicSystemIncludePaths` for FMOD related headers
2. Use `Path.Combine(ModuleDirectory` instead of `"FMODStudio/"` (see https://issues.unrealengine.com/issue/UE-60969)