### PR TITLE
Occlusion Trace Channel now does something.

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
@@ -237,7 +237,7 @@ void UFMODAudioComponent::UpdateAttenuation()
 		const FVector& Location = GetOwner()->GetTransform().GetTranslation();
 		const FFMODListener& Listener = IFMODStudioModule::Get().GetNearestListener(Location);
 
-		bool bIsOccluded = GWorld->LineTraceTestByChannel(Location, Listener.Transform.GetLocation(), ECC_Visibility, Params);
+		bool bIsOccluded = GWorld->LineTraceTestByChannel(Location, Listener.Transform.GetLocation(), OcclusionDetails.OcclusionTraceChannel, Params);
 
 		// Apply directly as gain and LPF
 		if (bApplyOcclusionDirect)


### PR DESCRIPTION
The Occlusion Trace Channel that is an option for FMOD Audio Components doesn't actually do anything. Instead, it always traces against `ECC_Visibility`. This pull request fixes that.