### PR TITLE
Add Blueprint node for EventInstance::getPlaybackState

### DIFF
--- a/FMODStudio/Source/FMODStudio/Classes/FMODBlueprintStatics.h
+++ b/FMODStudio/Source/FMODStudio/Classes/FMODBlueprintStatics.h
@@ -38,6 +38,16 @@ enum EFMOD_STUDIO_STOP_MODE
     IMMEDIATE
 };
 
+UENUM(BlueprintType) 
+enum EFMOD_STUDIO_PLAYBACK_STATE 
+{ 
+	PLAYBACK_PLAYING	UMETA(DisplayName = "Playing"), 
+	PLAYBACK_SUSTAINING	UMETA(DisplayName = "Sustaining"), 
+	PLAYBACK_STOPPED	UMETA(DisplayName = "Stopped"), 
+	PLAYBACK_STARTING	UMETA(DisplayName = "Starting"), 
+	PLAYBACK_STOPPING	UMETA(DisplayName = "Stopping") 
+}; 
+
 UCLASS()
 class FMODSTUDIO_API UFMODBlueprintStatics : public UBlueprintFunctionLibrary
 {
@@ -265,6 +275,12 @@ class FMODSTUDIO_API UFMODBlueprintStatics : public UBlueprintFunctionLibrary
 	 */
     UFUNCTION(BlueprintCallable, Category = "Audio|FMOD|EventInstance", meta = (UnsafeDuringActorConstruction = "true"))
     static void EventInstanceSetTransform(FFMODEventInstance EventInstance, const FTransform &Location);
+
+    /** Retrieves the playback state of a FMOD Event Instance
+	 * @param EventInstance - Event instance
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Audio|FMOD|EventInstance", meta = (UnsafeDuringActorConstruction = "true"))
+	static EFMOD_STUDIO_PLAYBACK_STATE EventInstanceGetPlaybackState(FFMODEventInstance EventInstance);
 
     /** List all output device names.
 	 */

--- a/FMODStudio/Source/FMODStudio/Private/FMODBlueprintStatics.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODBlueprintStatics.cpp
@@ -505,6 +505,20 @@ void UFMODBlueprintStatics::EventInstanceSetTransform(FFMODEventInstance EventIn
     }
 }
 
+EFMOD_STUDIO_PLAYBACK_STATE UFMODBlueprintStatics::EventInstanceGetPlaybackState(FFMODEventInstance EventInstance) 
+{ 
+	FMOD_STUDIO_PLAYBACK_STATE state; 
+	if (EventInstance.Instance) 
+	{ 
+		FMOD_RESULT Result = EventInstance.Instance->getPlaybackState(&state); 
+		if (Result != FMOD_OK) 
+		{ 
+			UE_LOG(LogFMOD, Warning, TEXT("Failed to get event instance playback state")); 
+		} 
+	} 
+	return (EFMOD_STUDIO_PLAYBACK_STATE)state; 
+}
+
 TArray<FString> UFMODBlueprintStatics::GetOutputDrivers()
 {
     TArray<FString> AllNames;


### PR DESCRIPTION
I use EventInstance::getPlaybackState in Unity all the time, so I thought it would be nice to have this exposed in Blueprints. Just a small addition that I personally find useful 😊 .

Blueprint node:

![grafik](https://user-images.githubusercontent.com/26153311/71544783-9ece5b80-2983-11ea-9b94-e59b98cc4fcb.png)
