### PR TITLE
Fix compilation for non-unity build

### DIFF
--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODStudioEditorModule.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODStudioEditorModule.cpp
@@ -1,6 +1,8 @@
 // Copyright (c), Firelight Technologies Pty, Ltd. 2012-2020.
 
 #include "FMODStudioEditorModule.h"
+
+#include "FMODStudioEditorPrivatePCH.h"
 #include "FMODStudioModule.h"
 #include "FMODStudioStyle.h"
 #include "FMODAudioComponent.h"


### PR DESCRIPTION
You can test it with -StrictHeaders option for BuildPlugin or set bUseUnityBuild = false;