### PR TITLE
Compiler fix for UE4_27

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/Sequencer/FMODEventControlSectionTemplate.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/Sequencer/FMODEventControlSectionTemplate.cpp
@@ -21,7 +21,11 @@ struct FPlayingToken : IMovieScenePreAnimatedToken
         }
     }
 
-    virtual void RestoreState(UObject &Object, IMovieScenePlayer &Player) override
+#if ENGINE_MINOR_VERSION > 26
+	virtual void RestoreState(UObject& Object, const UE::MovieScene::FRestoreStateParams& Params) override
+#else
+	virtual void RestoreState(UObject& Object, IMovieScenePlayer& Player) override
+#endif
     {
         UFMODAudioComponent *AudioComponent = CastChecked<UFMODAudioComponent>(&Object);
 

--- a/FMODStudio/Source/FMODStudio/Private/Sequencer/FMODEventParameterSectionTemplate.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/Sequencer/FMODEventParameterSectionTemplate.cpp
@@ -14,7 +14,11 @@ struct FFMODEventParameterPreAnimatedToken : IMovieScenePreAnimatedToken
     FFMODEventParameterPreAnimatedToken(FFMODEventParameterPreAnimatedToken &&) = default;
     FFMODEventParameterPreAnimatedToken &operator=(FFMODEventParameterPreAnimatedToken &&) = default;
 
-    virtual void RestoreState(UObject &Object, IMovieScenePlayer &Player) override
+#if ENGINE_MINOR_VERSION > 26
+	virtual void RestoreState(UObject& Object, const UE::MovieScene::FRestoreStateParams& Params) override
+#else
+	virtual void RestoreState(UObject& Object, IMovieScenePlayer& Player) override
+#endif
     {
         UFMODAudioComponent *AudioComponent = CastChecked<UFMODAudioComponent>(&Object);
 


### PR DESCRIPTION
Added a correction to the usage of the RestoreState function override in UE 4.27.

Due to the included macro, this will compile both for 4.26 and 4.27 without any changes from the user.