### PR TITLE
Initialize COM before making any calls to FMOD API

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODStudioModule.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODStudioModule.cpp
@@ -421,6 +421,14 @@ FString FFMODStudioModule::GetDllPath(const TCHAR *ShortName, bool bExplicitPath
 
 bool FFMODStudioModule::LoadLibraries()
 {
+#if PLATFORM_WINDOWS
+	if (!FWindowsPlatformMisc::CoInitialize())
+	{
+		UE_LOG(LogFMOD, Error, TEXT("Could not initialize COM library!"));
+		return false;
+	}
+#endif
+
 #if PLATFORM_IOS || PLATFORM_TVOS || PLATFORM_ANDROID || PLATFORM_LINUX || PLATFORM_MAC || defined(FMOD_DONT_LOAD_LIBRARIES)
     return true; // Nothing to do on those platforms
 #else


### PR DESCRIPTION
According to [FMOD documentation], user must call CoInitialize before accessing any FMOD API.

However, FMOD plugin doesn't do that explicitly.
Unreal Engine itself also doesn't guarantee that CoInitialize will be called before FMOD plugin startup.

This commit partially fixes issues discovered when trying to run FMOD plugin in [Unreal Engine containers].

[FMOD documentation]: https://fmod.com/resources/documentation-api?version=2.00&page=platforms-win.html#com
[Unreal Engine containers]: https://qa.fmod.com/t/multiple-errors-running-unreal-engine-plugin-in-docker-containers/17966