### PR TITLE
Update PlatformFileManager include path

### DIFF
--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODGenerateAssetsCommandlet.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODGenerateAssetsCommandlet.cpp
@@ -6,7 +6,7 @@
 #include "AssetRegistryModule.h"
 #include "Editor.h"
 #include "Editor/UnrealEd/Public/FileHelpers.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "../Classes/FMODAssetBuilder.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogFMODCommandlet, Log, All);


### PR DESCRIPTION
`HAL/PlatformFilemanager.h` has been renamed to `HAL/PlatformFileManager.h`. 

Please refer to the [4.27](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/HAL/FPlatformFileManager/) and [5.0](https://docs.unrealengine.com/5.0/en-US/API/Runtime/Core/HAL/FPlatformFileManager/) documentation for reference. 

This also fixes compilation on Linux.

