### PR TITLE
Do not override parameter cache values

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAudioComponent.cpp
@@ -342,7 +342,7 @@ void UFMODAudioComponent::CacheDefaultParameterValues()
         {
             if (ShouldCacheParameter(ParameterDescription))
             {
-                ParameterCache.Add(ParameterDescription.name, ParameterDescription.defaultvalue);
+                ParameterCache.FindOrAdd(ParameterDescription.name, ParameterDescription.defaultvalue);
             }
         }
         bDefaultParameterValuesCached = true;


### PR DESCRIPTION
In some cases it's needed to access parameter cache values that were set through the UE editor. The default behaviour doesn't allows it.