### PR TITLE
Suppressed warning about banks with locales not matching setting, when they actually do

### DIFF
--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODAssetBuilder.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODAssetBuilder.cpp
@@ -266,20 +266,23 @@ void FFMODAssetBuilder::BuildBankLookup(const FString &AssetName, const FString 
             FString* otherBankPath = BankGuids.Find(GUID);
             if (otherBankPath != nullptr)
             {
-                bool foundLocale = false;
+            	enum { LocaleNotFound, DefaultLocale, OtherLocale } locale = LocaleNotFound;
                 for (const FFMODProjectLocale& Locale : InSettings.Locales)
                 {
                     if (BankPath.EndsWith(FString("_") + Locale.LocaleCode + FString(".bank")))
                     {
-                        foundLocale = true;
+                    	locale = Locale.bDefault ? DefaultLocale : OtherLocale;
                         break;
                     }
                 }
-                if (!foundLocale)
+                if (locale == LocaleNotFound)
                 {
-                    UE_LOG(LogFMOD, Warning, TEXT("Ignoring bank %s as another bank with the same GUID is already being used.\n"
-                        "Bank %s does not match any locales in the FMOD Studio plugin settings."), *BankPath, *BankPath);
-                    continue;
+	                UE_LOG(LogFMOD, Warning, TEXT("Ignoring bank %s as another bank with the same GUID is already being used.\n"
+						"Bank %s does not match any locales in the FMOD Studio plugin settings."), *BankPath, *BankPath);
+                }
+                if (locale != DefaultLocale)
+                {
+	                continue;
                 }
             }
             BankGuids.Add(GUID, BankPath);

--- a/FMODStudio/Source/FMODStudioEditor/Private/FMODAssetBuilder.cpp
+++ b/FMODStudio/Source/FMODStudioEditor/Private/FMODAssetBuilder.cpp
@@ -269,7 +269,7 @@ void FFMODAssetBuilder::BuildBankLookup(const FString &AssetName, const FString 
                 bool foundLocale = false;
                 for (const FFMODProjectLocale& Locale : InSettings.Locales)
                 {
-                    if (Locale.bDefault && BankPath.EndsWith(FString("_") + Locale.LocaleCode + FString(".bank")))
+                    if (BankPath.EndsWith(FString("_") + Locale.LocaleCode + FString(".bank")))
                     {
                         foundLocale = true;
                         break;


### PR DESCRIPTION
Banks with non-default locale are never recognized even if suffix is correct