### PR TITLE
Fix FindObject function no longer taking in enum in 5.7

### DIFF
--- a/FMODStudio/Source/FMODStudio/Private/FMODAssetTable.cpp
+++ b/FMODStudio/Source/FMODStudio/Private/FMODAssetTable.cpp
@@ -49,7 +49,7 @@ void FFMODAssetTable::Load()
     FString PackageName = PackagePath + BankLookupName();
     UPackage *Package = CreatePackage(*PackageName);
     Package->FullyLoad();
-    BankLookup = FindObject<UFMODBankLookup>(Package, *BankLookupName(), EFindObjectFlags::ExactClass);
+    BankLookup = FindObject<UFMODBankLookup>(Package, *BankLookupName());
 
     if (BankLookup)
     {
@@ -73,7 +73,7 @@ void FFMODAssetTable::Load()
     PackageName = PackagePath + AssetLookupName();
     Package = CreatePackage(*PackageName);
     Package->FullyLoad();
-    AssetLookup = FindObject<UDataTable>(Package, *AssetLookupName(), EFindObjectFlags::ExactClass);
+    AssetLookup = FindObject<UDataTable>(Package, *AssetLookupName());
 
     if (AssetLookup)
     {
@@ -227,3 +227,4 @@ UFMODAsset *FFMODAssetTable::GetAssetByStudioPath(const FString &InStudioPath) c
 
     return Asset;
 }
+


### PR DESCRIPTION
Removes the final enum from the function so that it can compile for 5.7